### PR TITLE
Made dependency installation optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+install_dependencies: True
+
 yum_dependencies:
     - git
     - python-pip

--- a/tasks/create-virtualenv.yml
+++ b/tasks/create-virtualenv.yml
@@ -1,10 +1,12 @@
 ---
 - name: Setup pre-requisite python packages
+  when: install_dependencies | bool
   package:
     name: "{{ yum_dependencies }}"
     state: present
 
 - name: Setup pre-requisite pip packages
+  when: install_dependencies | bool
   pip:
     name: "{{ pip_dependencies }}"
     state: present


### PR DESCRIPTION
I need to install this in a UBI based container image. I am installing the dependencies before calling this role (there is no way to tell ansible package module to ignore specific repos). Therefore I added a variable install_dependencies with default true that I can override to false when installing in a container.